### PR TITLE
Test setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: make serve

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Building Websites with Jekyll and GitHub/GitLab
 
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/carpentries-incubator/building-websites-with-jekyll-and-github-or-gitlab)
 [![DOI](https://zenodo.org/badge/268807168.svg)](https://zenodo.org/badge/latestdoi/268807168)
 
 


### PR DESCRIPTION
I showed this to Toby the other day and had a chance to try it today on a fork.

Seems to work wonderfully well. Below is a screenshot of a browser tab (bonkers!!).

![screenshot_2020-10-05_22-04-17_891366597](https://user-images.githubusercontent.com/122319/95126518-f097e380-0756-11eb-8d7f-b4d1d4ef41d8.png)

This pull request adds the necessary files and a badge on the README to do a one-click launch.
You can give it a quick spin directly from here (using my repo for now): [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/unode/building-websites-with-jekyll-and-github-or-gitlab/tree/unode/gitpod-setup)

Currently takes a couple of minutes to start jekyll as it installs all dependencies on first launch, but after that, a little pop-up is shown and:

![screenshot_2020-10-05_22-08-04_041480769](https://user-images.githubusercontent.com/122319/95126797-453b5e80-0757-11eb-9645-2e1c1263f167.png)

If you click on "Preview" or "Open browser" you can see the result live. If you click "Make public" you can even show to someone else before making it final.

I think this is an amazing accessibility boost. Thoughts?