### PR TITLE
use relative image path

### DIFF
--- a/_episodes/includes.md
+++ b/_episodes/includes.md
@@ -109,7 +109,7 @@ add this HTML immediately after the YAML front matter in `index.md`:
 <img src="/images/site_banner.png" alt="Group Website with Jekyll">
 ```
 
-![Group Website with Jekyll](/files/site_banner.png)
+![Group Website with Jekyll](../files/site_banner.png)
 
 Adding this `img` element should result in this title banner appearing
 at the top of your page.


### PR DESCRIPTION
get the banner image to render on the page in Re-using Blocks of Content.

This suggests we will have issues with the image paths during the workshop too - something to keep an eye out for while working through the material this week @unode @JulianKarlBauer @annefou 