### PR TITLE
Carry over the reference to about.md

### DIFF
--- a/_episodes/github-pages.md
+++ b/_episodes/github-pages.md
@@ -164,9 +164,8 @@ We are now ready to start adding more content to our website. Let's do some exer
 > >
 > >        ## Contact us
 > >
-> >        Email: [team@my.research.org](mailto:team@my.research.org)
-> >
-> >        Twitter: [@my_research_project](https://twitter.com/my_research_project)
+> >         - Email: [team@my.research.org](mailto:team@my.research.org)
+> >         - Twitter: [@my_research_project](https://twitter.com/my_research_project)
 > >
 > >     Note how we used various Markdown syntax: quoted text ('>'), italic font ('*') and external links
 > >     (square '[]' and round brackets '()' for mailto and regular Web URLs).

--- a/_episodes/starting-jekyll.md
+++ b/_episodes/starting-jekyll.md
@@ -78,6 +78,8 @@ Let's make use of global parameters in our pages.
 ## Description
 {% raw %}{{ site.description }}{% endraw %}
 
+More details about the project are available from the [About page](about).
+
 Have any questions about what we do? [We'd love to hear from you!]({% raw %}mailto:{{ site.email }}{% endraw %})
 ~~~  
    
@@ -207,6 +209,8 @@ Between these triple-dashed lines, you can overwrite predefined variables (like 
 > >   
 > > ## Description
 > > {% raw %}{{ site.description }}{% endraw %}
+> > 
+> > More details about the project are available from the [About page](about).
 > >                                    
 > > See some [examples of our work]({% raw %}{{{% endraw %} page.example-lesson {% raw %}}}{% endraw %}).
 > >


### PR DESCRIPTION
I followed the instructions step by step and lost the reference to `about.md` along the way.
Was this intended?
