### PR TITLE
Fix `line breaks` in exercise

### DIFF
--- a/_episodes/markdown.md
+++ b/_episodes/markdown.md
@@ -100,7 +100,7 @@ Let's do some exercises to learn more about structuring and emphasis.
 > >     Vanilla text may contain *italic* and **bold words**.
 > >
 > >     This paragraph is separated from the previous one by a blank line.
-> >     Line breaks
+> >     Line breaks  
 > >     are caused by two trailing spaces at the end a line.
 > >
 > {: .solution }


### PR DESCRIPTION
I see at least two ways to fix this exercise:
1. Variant: Reject this merge request and do talk about line breaks due 
to two trailing whitespaces in this exercise.
Change the name of the exercise.
2. Update the screen shot solution including line break and merge this 
request. Keep the name of the exercise.