### PR TITLE
syntax highlighting for Markdown & HTML blocks

### DIFF
--- a/_episodes/filters.md
+++ b/_episodes/filters.md
@@ -41,17 +41,14 @@ the first thing we need to do is create a new layout for these posts,
 inheriting from the default layout we created earlier.
 
 ~~~
-{% raw %}
----
+{% raw %}---
 layout: default
 ---
 
 <strong>Author:</strong> {{page.author}}
 Published on {{ page.publication_date }}
 
-{{ content }}
-
-{% endraw %}
+{{ content }}{% endraw %}
 ~~~
 {: .language-html }
 
@@ -61,17 +58,14 @@ remembering to add the `author` and `publication_date` fields
 to the YAML front matter:
 
 ~~~
-{% raw %}
----
+{% raw %}---
 layout: post
 title: I am a Surgeon!
 author: Dr James Barry
 publication_date: 1827-11-22
 ---
 
-Today was a good day. I was promoted to Surgeon to the Forces!
-
-{% endraw %}
+Today was a good day. I was promoted to Surgeon to the Forces!{% endraw %}
 ~~~
 {: .language-markdown }
 
@@ -118,9 +112,7 @@ a more human format (e.g. 4th September 2019) at the top of each post,
 using a _Filter_:
 
 ~~~
-{% raw %}
-Published on {{ page.publication_date | date_to_long_string: "ordinal" }}
-{% endraw %}
+{% raw %}Published on {{ page.publication_date | date_to_long_string: "ordinal" }}{% endraw %}
 ~~~
 {: .language-markdown }
 

--- a/_episodes/filters.md
+++ b/_episodes/filters.md
@@ -53,7 +53,7 @@ Published on {{ page.publication_date }}
 
 {% endraw %}
 ~~~
-{: .source }
+{: .language-html }
 
 Save this layout to `_layouts/post.html`.
 Now we can create our first blog post, `1827-11-22-surgeon.md`,
@@ -73,7 +73,7 @@ Today was a good day. I was promoted to Surgeon to the Forces!
 
 {% endraw %}
 ~~~
-{: .source }
+{: .language-markdown }
 
 FIXME: add screenshot of rendered blog post.
 
@@ -99,7 +99,7 @@ our post layout.
 > >
 > > Good news: I have been promoted to Deputy Inspector-General of Hospitals.
 > > ~~~
-> > {: .source }
+> > {: .language-markdown }
 > {: .solution }
 {: .challenge }
 
@@ -122,7 +122,7 @@ using a _Filter_:
 Published on {{ page.publication_date | date_to_long_string: "ordinal" }}
 {% endraw %}
 ~~~
-{: .source }
+{: .language-markdown }
 
 FIXME: add screenshot of rendered publication date
 

--- a/_episodes/github-pages.md
+++ b/_episodes/github-pages.md
@@ -129,10 +129,13 @@ We are now ready to start adding more content to our website. Let's do some exer
 > > ## Solution
 > > 1. Edit `index.md` file to look something like:
 > >
-> >        # My Research Project
+> > ~~~
+> > # My Research Project
 > >
-> >        ## Description
-> >        This research project is all about teaching you how to create websites with GitHub pages.
+> > ## Description
+> > This research project is all about teaching you how to create websites with GitHub pages.
+> > ~~~
+> > {: .language-markdown }
 > >
 > > 2. Go to your website. It should now look like:
     ![Add About section to index](../fig/episode03_exercise01_add_description.png)
@@ -184,36 +187,42 @@ are both valid link targets
 > > ## Solution
 > > 1. Create new file called `about.md` from the GitHub interface:
     ![Create file](../fig/github_create_file.png)
-> > Edit `about.md` file to look something like:
+> >     Edit `about.md` file to look something like:
 > >
-> >        # About
+> >     ~~~
+> >     # About
 > >
-> >        ## Project
-> >        This reseach project is all about teaching you how to create websites with GitHub pages.
+> >     ## Project
+> >     This reseach project is all about teaching you how to create websites with GitHub pages.
 > >
-> >        ## Funders
-> >        We gratefully acknowledge funding from the XYZ Founding Council, under grant number 'abc'.
+> >     ## Funders
+> >     We gratefully acknowledge funding from the XYZ Founding Council, under grant number 'abc'.
 > >
-> >        ## Cite us
-> >        You can cite the project as:
+> >     ## Cite us
+> >     You can cite the project as:
 > >
-> >        >    *My research project. Zenodo. https://zenodo.org/record/doi*
+> >     >    *My research project. Zenodo. https://zenodo.org/record/doi*
 > >
-> >        ## Contact us
+> >     ## Contact us
 > >
-> >         - Email: [team@my.research.org](mailto:team@my.research.org)
-> >         - Twitter: [@my_research_project](https://twitter.com/my_research_project)
+> >     - Email: [team@my.research.org](mailto:team@my.research.org)
+> >     - Twitter: [@my_research_project](https://twitter.com/my_research_project)
+> >     ~~~
+> >     {: .language-markdown }
 > >
 > >     Note how we used various Markdown syntax: quoted text (`>`), italic font (`*`) and external links
 > >     (a combination of square `[]` and round brackets `()` containing the link text and mailto or regular Web URLs respectively).
 > > 2. Edit `index.md` to add a link to `about.md`.
 > >
-> >        # My Research Project
+> >     ~~~
+> >     # My Research Project
 > >
-> >        ## Description
-> >        This research project is all about teaching you how to create websites with GitHub Pages.
+> >     ## Description
+> >     This research project is all about teaching you how to create websites with GitHub Pages.
 > >
-> >        More details about the project are available from the [About page](about).
+> >     More details about the project are available from the [About page](about).
+> >     ~~~
+> >     {: .language-markdown }
 > >
 > >  3. Go to your website and click the link to 'About' page. It should look like:
     ![About page](../fig/episode03_exercise01_about_page.png)

--- a/_episodes/github-pages.md
+++ b/_episodes/github-pages.md
@@ -179,54 +179,58 @@ are both valid link targets
 (assuming the relevant files exist in your repository).
 
 > ## Exercise: Create Links Between Pages
+>
 > Create a new file `about.md` and link to it from `index.md`.
 > 1. From the GitHub interface, create a new Markdown file called `about.md` and add some content to it.
 > 2. Add a link to `about.md` from `index.md`.
 > 3. View the changes on the website.
 >
 > > ## Solution
+> >
 > > 1. Create new file called `about.md` from the GitHub interface:
-    ![Create file](../fig/github_create_file.png)
-> >     Edit `about.md` file to look something like:
+> >    ![Create file](../fig/github_create_file.png)
+> >    Edit `about.md` file to look something like:
 > >
-> >     ~~~
-> >     # About
+> >    ~~~
+> >    # About
 > >
-> >     ## Project
-> >     This reseach project is all about teaching you how to create websites with GitHub pages.
+> >    ## Project
+> >    This reseach project is all about teaching you how to create websites with GitHub pages.
 > >
-> >     ## Funders
-> >     We gratefully acknowledge funding from the XYZ Founding Council, under grant number 'abc'.
+> >    ## Funders
+> >    We gratefully acknowledge funding from the XYZ Founding Council, under grant number 'abc'.
 > >
-> >     ## Cite us
-> >     You can cite the project as:
+> >    ## Cite us
+> >    You can cite the project as:
 > >
-> >     >    *My research project. Zenodo. https://zenodo.org/record/doi*
+> >    > *My research project. Zenodo. https://zenodo.org/record/doi*
 > >
-> >     ## Contact us
+> >    ## Contact us
 > >
-> >     - Email: [team@my.research.org](mailto:team@my.research.org)
-> >     - Twitter: [@my_research_project](https://twitter.com/my_research_project)
-> >     ~~~
-> >     {: .language-markdown }
+> >    - Email: [team@my.research.org](mailto:team@my.research.org)
+> >    - Twitter: [@my_research_project](https://twitter.com/my_research_project)
+> >    ~~~
+> >    {: .language-markdown }
 > >
-> >     Note how we used various Markdown syntax: quoted text (`>`), italic font (`*`) and external links
-> >     (a combination of square `[]` and round brackets `()` containing the link text and mailto or regular Web URLs respectively).
+> >    Note how we used various Markdown syntax: quoted text (`>`), italic font (`*`) and external links
+> >    (a combination of square `[]` and round brackets `()` containing the link text and mailto or regular Web URLs respectively).
+> >
 > > 2. Edit `index.md` to add a link to `about.md`.
 > >
-> >     ~~~
-> >     # My Research Project
+> >    ~~~
+> >    # My Research Project
 > >
-> >     ## Description
-> >     This research project is all about teaching you how to create websites with GitHub Pages.
+> >    ## Description
+> >    This research project is all about teaching you how to create websites with GitHub Pages.
 > >
-> >     More details about the project are available from the [About page](about).
-> >     ~~~
-> >     {: .language-markdown }
+> >    More details about the project are available from the [About page](about).
+> >    ~~~
+> >    {: .language-markdown }
 > >
-> >  3. Go to your website and click the link to 'About' page. It should look like:
-    ![About page](../fig/episode03_exercise01_about_page.png)
-> >     Note that the URL has '/about' appended to it - you can use this URL to access the 'About' page directly.
+> > 3. Go to your website and click the link to 'About' page. It should look like:
+> >    ![About page](../fig/episode03_exercise01_about_page.png)
+> >
+> >    Note that the URL has '/about' appended to it - you can use this URL to access the 'About' page directly.
 > {: .solution }
 {: .challenge }
 

--- a/_episodes/includes.md
+++ b/_episodes/includes.md
@@ -107,9 +107,10 @@ you can do this by navigating into the folder and choosing
 Now that the banner image is available in our site repository,
 add this Markdown immediately after the YAML front matter in `index.md`:
 
-```
+~~~
 ![Group Website banner](./images/site_banner.png)
-```
+~~~
+{: .language-markdown }
 
 ![Group Website banner](../files/site_banner.png)
 
@@ -155,9 +156,10 @@ at the top of your page.
 >
 > > ## Solution
 > >
-> > ```
+> > ~~~
 > > [![Group Website with Jekyll](./images/site_banner.png)](https://YOUR_USERNAME.github.io/YOUR_REPO_NAME/)
-> > ```
+> > ~~~
+> > {: .language-markdown }
 > >
 > {: .solution }
 {: .challenge }
@@ -186,9 +188,10 @@ dropdown on your repository homepage,
 Now delete the HTML block you added to `index.md`,
 and replace it with the following `_includes` tag:
 
-```
+~~~
 {% raw %}{% include banner.md %}{% endraw %}
-```
+~~~
+{: .language-markdown }
 
 Refresh the page and, barring any typos e.g. in the name of the file,
 you should see the banner image on the page as before.
@@ -227,7 +230,7 @@ We will see another example of this shortly.
 > - Email: [{% raw %}{{ site.email }}{% endraw %}](mailto:{% raw %}{{ site.email }}{% endraw %})
 > - Twitter: [{% raw %}{{ site.twitter }}{% endraw %}]({% raw %}{{ site.twitter }}{% endraw %})
 > ~~~
-> {: .source }
+> {: .language-markdown }
 >
 > Copy the snippet and save it into an appropriately-named file,
 > then use an `include` statement to re-insert it
@@ -244,14 +247,14 @@ We will see another example of this shortly.
 > > - Email: [{% raw %}{{ site.email }}{% endraw %}](mailto:{% raw %}{{ site.email }}{% endraw %})
 > > - Twitter: [{% raw %}{{ site.twitter }}{% endraw %}]({% raw %}{{ site.twitter }}{% endraw %})
 > > ~~~
-> > {: .source }
+> > {: .language-markdown }
 > >
 > > and add the line
 > >
 > > ~~~
 > > {% raw %}{% include contact.md %}{% endraw %}
 > > ~~~
-> > {: .source }
+> > {: .language-markdown }
 > >
 > > at the end of `index.md` and `about.md`
 > > (replacing the equivalent section if it is still present).

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -52,7 +52,7 @@ HTML documents tend to get verbose rather quickly.
 
 The simplest, valid HTML `Hello world` is:
 
-```html
+~~~
 <!DOCTYPE html>
 <html>
   <head>
@@ -62,7 +62,8 @@ The simplest, valid HTML `Hello world` is:
     <p>Hello World</p>
   </body>
 </html>
-```
+~~~
+{: .language-html }
 
 So as you can imagine, writing long HTML documents by hand is rather painful.
 Notice that we didn't specify anything about how and where the text should be displayed.
@@ -92,14 +93,15 @@ a web browser will make a best guess regarding the layout of HTML elements on th
 >
 > <h1><em>Hello</em> <strong>World</strong></h1>
 >
-> write the HTML will produce the same result.  
+> write the HTML will produce the same result.
 > **Hint** the big font is achieved by use of a heading.
 >
 > > ## Solution
 > >
-> > ```html
+> > ~~~
 > > <h1><em>Hello</em> <strong>World</strong></h1>
-> > ```
+> > ~~~
+> > {: .language-html }
 > {: .solution }
 {: .challenge }
 
@@ -224,7 +226,7 @@ Under the "Repository name" field type `group-website`.
 <img src="../fig/set_repo_name.png" alt="Repository name set to group-website" width="600">
 
 
-We can also add a description (for instance **Repo for learning how to make websites with jekyll pages**) so we know what this repo is when we find it again after the workshop. 
+We can also add a description (for instance **Repo for learning how to make websites with jekyll pages**) so we know what this repo is when we find it again after the workshop.
 
 <img src="../fig/set_repo_description.png" alt="Repository name set to group-website" width="600">
 

--- a/_episodes/layouts.md
+++ b/_episodes/layouts.md
@@ -52,7 +52,7 @@ as an `<img>` element in HTML:
 ~~~
 ![Group Website banner](./images/site_banner.png)
 ~~~
-{: .source }
+{: .language-markdown }
 
 #### After
 
@@ -69,7 +69,7 @@ we will start with a layout file that only `include`s this file:
 ~~~
 {% raw %}{% include banner.html %}{% endraw %}
 ~~~
-{: .source}
+{: .language-markdown }
 
 You have just defined the first layout for pages on your site.
 Congratulations!
@@ -91,7 +91,7 @@ To do that we need to add the special `content` variable into the layout file:
 
 {% raw %}{{ content }}{% endraw %}
 ~~~
-{: .source}
+{: .language-markdown }
 
 We can use the `content` variable to tell variable where it should place
 **all the content defined in the Markdown of the page** within this layout.
@@ -148,7 +148,7 @@ so we will come back to this issue of styling at the end of the section.
 > > <li>Twitter: <a href="https://twitter.com/my_research_project">@my_research_project</a></li>
 > > </ul>
 > > ~~~
-> > {: .source }
+> > {: .language-html }
 > >
 > > and your layout file, `_layouts/page.html`,
 > > should look like this:
@@ -160,7 +160,7 @@ so we will come back to this issue of styling at the end of the section.
 > >
 > > {% include contact.html %}{% endraw %}
 > > ~~~
-> > {: .source }
+> > {: .language-html }
 > {: .solution }
 {: .challenge }
 
@@ -215,7 +215,7 @@ This file defines the bare minimum layout your pages should have.
 >   </body>
 > </html>{% endraw %}
 > ~~~
-> {: .source }
+> {: .language-html }
 >
 > 1. Apply this layout to one of your pages and reload the page to check that
 >    it works as expected.
@@ -236,7 +236,7 @@ This file defines the bare minimum layout your pages should have.
 > >   An example website made with Jekyll.
 > > </footer>{% endraw %}
 > > ~~~
-> > {: .source }
+> > {: .language-html }
 > >
 > > And to `include` it back into the layout,
 > > replace that `footer` element with
@@ -244,7 +244,7 @@ This file defines the bare minimum layout your pages should have.
 > > ~~~
 > > {% raw %}{% include footer.html %}{% endraw %}
 > > ~~~
-> > {: .source }
+> > {: .language-html }
 > {: .solution}
 {: .challenge }
 
@@ -265,18 +265,15 @@ we should add YAML front matter to the layout file,
 specifying the `layout` to be `default`:
 
 ~~~
-{% raw %}
----
+{% raw %}---
 layout: default
 ---
 
 {{ content }}
 
-{% include contact.md}
-
-{% endraw %}
+{% include contact.md}{% endraw %}
 ~~~
-{: .source }
+{: .language-html }
 
 In the above, we have (once again!) removed the banner image,
 as that is included in the `default` layout.

--- a/_episodes/markdown.md
+++ b/_episodes/markdown.md
@@ -88,7 +88,7 @@ Repo for learning how to make websites with Jekyll pages
 Vanilla text may contain *italic* and **bold words**.
 
 This paragraph is separated from the previous one by a blank line.
-Line breaks  
+Line breaks
 are caused by two trailing spaces at the end of a line.
 
 [Carpentries Webpage](https://carpentries.org/)
@@ -123,7 +123,7 @@ Let's do an exercise to try out writing more markdown.
 >
 > > ## Example Solution
 > > For example your markdown might look like the following:
-> > ```
+> > ~~~
 > > ## More info on the lesson
 > > You can find this lesson [here](https://carpentries-incubator.github.io/building-websites-with-jekyll-and-github-or-gitlab/).
 > >
@@ -135,7 +135,8 @@ Let's do an exercise to try out writing more markdown.
 > > 4. We ~~don't~~ use it in The Carpentries
 > >
 > > ![Carpentries Logo](https://github.com/carpentries/carpentries.org/raw/main/images/TheCarpentries-opengraph.png)
-> > ```
+> > ~~~
+> > {: .language-markdown }
 > > <img src="../fig/markdown_exercise.png" alt="Rendered solution to the markdown exercise" width="width=800">
 > >
 > {: .solution }

--- a/_episodes/starting-jekyll.md
+++ b/_episodes/starting-jekyll.md
@@ -13,27 +13,27 @@ objectives:
 keypoints:
 - "Variables can be defined globally in `_config.yml` or locally within YAML header (*front matter*) of a page"
 - "Variable values can be substituted into page content with Liquid notation: `{{ variable }}`"
-- "Global variables are accessible from any page of your website; local variables can only be accessed within 
+- "Global variables are accessible from any page of your website; local variables can only be accessed within
 the page in which they were defined (and any pages that include this page)"
 ---
 
 [Jekyll](https://jekyllrb.com/) is a powerful static site generator behind GitHub Pages. It creates static HTML
 website content out of various files in your repository (Markdown files, CSS style sheets, page templates/layouts, etc.).
 This 'compiled' content is then served as your website via the `github.io` Web domain (remember your website's URL
-from the previous episode?). Jekyll automatically re-generates all the HTML pages for your website each time you 
+from the previous episode?). Jekyll automatically re-generates all the HTML pages for your website each time you
 make a change to your repository.
 
-Jekyll makes managing your website easier because it depends on templates. 
-Templates (or layouts in Jekyll notation) are blueprints that can be reused by multiple pages. 
-For example, instead of repeating the same navigation markup on every page you create 
+Jekyll makes managing your website easier because it depends on templates.
+Templates (or layouts in Jekyll notation) are blueprints that can be reused by multiple pages.
+For example, instead of repeating the same navigation markup on every page you create
 (such a header, a footer or a top navigation bar), you can create a Jekyll layout that gets used on all the pages.
-Otherwise, each time you update a navigation item - you'd have to make edits on every page. 
-We will cover Jekyll layouts in a bit; for now let's start learning Jekyll 
-and its scripting language called [Liquid](https://shopify.github.io/liquid/basics/introduction/). 
+Otherwise, each time you update a navigation item - you'd have to make edits on every page.
+We will cover Jekyll layouts in a bit; for now let's start learning Jekyll
+and its scripting language called [Liquid](https://shopify.github.io/liquid/basics/introduction/).
 
 ## Global Parameters
-Jekyll's main configuration options are specified in a `_config.yml` file, which is written in a language 
-called [YAML](https://yaml.org/) and placed in your site’s root directory. Parameters configured in `_config.yml` 
+Jekyll's main configuration options are specified in a `_config.yml` file, which is written in a language
+called [YAML](https://yaml.org/) and placed in your site’s root directory. Parameters configured in `_config.yml`
 are global or site-wide - that means they are accessible in every page of your website.
 
 > ## YAML
@@ -59,9 +59,9 @@ Let's create some configuration parameters for our website.
 3. Commit your changes.
 
 Global configuration settings from
-`_config.yml` are made available as `site.PARAMETER_NAME` variable in every page within the website. So, global parameter `email` we defined above would be accessed as `site.email`. 
+`_config.yml` are made available as `site.PARAMETER_NAME` variable in every page within the website. So, global parameter `email` we defined above would be accessed as `site.email`.
 
-In order to access the parameter's value within a page, you use Liquid's notation to output content by surrounding a variable in curly braces as `{% raw %}{{ variable }}{% endraw %}`. 
+In order to access the parameter's value within a page, you use Liquid's notation to output content by surrounding a variable in curly braces as `{% raw %}{{ variable }}{% endraw %}`.
 
 > ## Predefined Global Parameters
 >In addition to the global parameters you define, Jekyll also makes a number of
@@ -81,24 +81,25 @@ Let's make use of global parameters in our pages.
     More details about the project are available from the [About page](about).
 
     Have any questions about what we do? [We'd love to hear from you!]({% raw %}mailto:{{ site.email }}{% endraw %})
-    ~~~  
-   
-2. We can use the same parameter in different pages. Let's reuse `{% raw %}{{ site.description }}{% endraw %}` and 
+    ~~~
+    {: .language-markdown }
+
+2. We can use the same parameter in different pages. Let's reuse `{% raw %}{{ site.description }}{% endraw %}` and
 `{% raw %}{{ site.email }}{% endraw %}` in `about.md` like this:
 
-    ~~~ 
+    ~~~
     # About
 
     ## Project
-    
+
     {% raw %}{{ site.description }}{% endraw %}
-            
+
     ## Funders
-    
+
     We gratefully acknowledge funding from the XYZ Founding Council, under grant number 'abc'.
 
     ## Cite us
-    
+
     You can cite the project as:
 
     >    *My research project. Zenodo. https://zenodo.org/record/doi*
@@ -108,17 +109,18 @@ Let's make use of global parameters in our pages.
     - Email: [{% raw %}{{ site.email }}{% endraw %}](mailto:{% raw %}{{ site.email }}{% endraw %})
     - Twitter: [@my_research_project](https://twitter.com/my_research_project)
     ~~~
-    
+    {: .language-markdown }
+
 3. Go to your website to see the changes.
 4. Note that site parameters will not render nicely when viewing files in GitHub (they will be displayed as text
 `{% raw %}{{ site.PARAMETER_NAME }}{% endraw %}` rather than the parameter's rendered value) but will in the website.
 
-> ## Exercise 
-> In `about.md` we have a Twitter URL under the 'Contact us' section. That's one piece of information that could go into 
-> global parameters in `_config.yml` as you may want to repeat it on a footer of every page. 
+> ## Exercise
+> In `about.md` we have a Twitter URL under the 'Contact us' section. That's one piece of information that could go into
+> global parameters in `_config.yml` as you may want to repeat it on a footer of every page.
 > Make changes to your website to extract Twitter URL as a global parameter.
 > > ## Solution
-> > 1. Add parameter twitter to `_config.yml`: 
+> > 1. Add parameter twitter to `_config.yml`:
 > >
 > >    ~~~
 > >    title: "Building Websites in GitHub"
@@ -128,51 +130,52 @@ Let's make use of global parameters in our pages.
 > >    twitter: "https://twitter.com/my_research_project"
 > >    ~~~
 > >    {: .language-yaml}
-> > 
-> > 2. Make use of the twitter parameter in `about.md`: 
 > >
-> >     ~~~  
+> > 2. Make use of the twitter parameter in `about.md`:
+> >
+> >     ~~~
 > >     # About
-> >      
+> >
 > >     ## Project
-> >     
+> >
 > >     {% raw %}{{ site.description }}{% endraw %}
-> >           
+> >
 > >     ## Funders
-> >     
+> >
 > >     We gratefully acknowledge funding from the XYZ Founding Council, under grant number 'abc'.
-> >     
+> >
 > >     ## Cite us
-> >     
+> >
 > >     You can cite the project as:
-> >     
+> >
 > >     > *My research project. Zenodo. https://zenodo.org/record/doi*
-> >     
+> >
 > >     ## Contact us
-> >     
+> >
 > >     - Email: [{% raw %}{{ site.email }}{% endraw %}](mailto:{% raw %}{{ site.email }}{% endraw %})
 > >     - Twitter: [{% raw %}{{ site.twitter }}{% endraw %}]({% raw %}{{ site.twitter }}{% endraw %})
 > >     ~~~
-> >    
+> >     {: .language-markdown }
+> >
 > > 3. Note that you should not see any changes to your website really. However, you can now access your Twitter URL from
-> > any website page, should you need to.    
+> > any website page, should you need to.
 > {: .solution}
 {: .challenge}
 
 > ## Reuse and Reduce
-> Jekyll's global parameters are a useful way to keep all your site-wide configuration in 
-> a single place (even if you only use them once). In combination with Jekyll layouts/templates (to be covered in the next episode) they are a great way of creating reusable markup snippets that can be repeated on multiple or even on every page of your website. Reuse helps you reduce the amount of code you have to write.  
+> Jekyll's global parameters are a useful way to keep all your site-wide configuration in
+> a single place (even if you only use them once). In combination with Jekyll layouts/templates (to be covered in the next episode) they are a great way of creating reusable markup snippets that can be repeated on multiple or even on every page of your website. Reuse helps you reduce the amount of code you have to write.
 {: .callout}
 
 ## Local Parameters
 
-In addition to global (site-wide) parameters available via the `site` global variable, Jekyll makes _local_ (page-specific) information available to you via the `page` variable. 
+In addition to global (site-wide) parameters available via the `site` global variable, Jekyll makes _local_ (page-specific) information available to you via the `page` variable.
 Some of these are pre-defined - like `page.title`, which gives you the title of the page that is currently active/being visited. Others you can define yourself. Check this [list of predefined page parameters](https://jekyllrb.com/docs/variables#page-variables).
 
-You can define local parameters using YAML notation within a Markdown page by including it in a page header and delimiting the header with triple-dashed lines `---`. These headers are called *front matter* and are 
+You can define local parameters using YAML notation within a Markdown page by including it in a page header and delimiting the header with triple-dashed lines `---`. These headers are called *front matter* and are
 used to set variables and metadata on individual pages in your Jekyll site.
 
-> ## Front matter        
+> ## Front matter
 > From [Jekyll's website](https://jekyllrb.com/docs/front-matter/):
 >
 >   >   Any file that contains a YAML front matter block will be processed by Jekyll as a special file. The front matter must be the first thing in the file and must take the form of valid YAML set between triple-dashed lines.
@@ -189,13 +192,13 @@ author: "Danger Mouse"
 ~~~
 {: .language-yaml }
 
-Between these triple-dashed lines, you can overwrite predefined variables (like `page.layout` or `page.title`) or create custom ones you need locally on the page (like `page.author`). These variables will then be available for you to access using Liquid's tags {% raw %}{{{% endraw %} and {% raw %}}}{% endraw %} further down in the file and also in any files that include this one.                                                                                                                     
+Between these triple-dashed lines, you can overwrite predefined variables (like `page.layout` or `page.title`) or create custom ones you need locally on the page (like `page.author`). These variables will then be available for you to access using Liquid's tags {% raw %}{{{% endraw %} and {% raw %}}}{% endraw %} further down in the file and also in any files that include this one.
 
 > ## Exercise
 >
 > Let's practice making and using local variables. Think of a local variable you may want to use only in your `about.md` or `index.md` page.
-> If you cannot think of any, create a local variable called 'lesson-example' with the value 
-> of 'https://carpentries.github.io/lesson-example/' and reference it in your `index.md`. 
+> If you cannot think of any, create a local variable called 'lesson-example' with the value
+> of 'https://carpentries.github.io/lesson-example/' and reference it in your `index.md`.
 >
 > What did you add to your `index.md` to create this variable?
 > Where did you add the front matter in your `index.md`?
@@ -204,25 +207,27 @@ Between these triple-dashed lines, you can overwrite predefined variables (like 
 > > ## Solution
 > >
 > > Create a YAML header at the very top of `index.md` and add the `lesson-example` variable in between the
-> > triple-dash delimiters. You can then reference the value within your `index.md` page as 
+> > triple-dash delimiters. You can then reference the value within your `index.md` page as
 `{% raw %}{{{% endraw %} page.lesson-example {% raw %}}}{% endraw %}`. Your file should now look like:
-> > 
+> >
 > > ~~~
-> > ---  
+> > ---
 > > lesson-example: "https://carpentries.github.io/lesson-example/"
-> > ---    
-> >    
+> > ---
+> >
 > > # {% raw %}{{ site.title }}{% endraw %}
-> >   
+> >
 > > ## Description
 > > {% raw %}{{ site.description }}{% endraw %}
-> > 
+> >
 > > More details about the project are available from the [About page](about).
-> >                                    
+> >
 > > See some [examples of our work]({% raw %}{{{% endraw %} page.lesson-example {% raw %}}}{% endraw %}).
 > >
 > > Have any questions about what we do? [We'd love to hear from you!]({% raw %}mailto:{{ site.email }}{% endraw %})
 > > ~~~
+> > {: .language-markdown }
+> > 
 > > Note that this variable is not accessible from `about.md` page and is local to `index.md`.
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
closes #129 

If you can figure out how to get the highlighting to work properly for the blocks in the solution to "Create Links Between Pages" exercise in `github-pages.md`, I will be extremely grateful! But feel free to merge without doing that, if you prefer 😄 