### PR TITLE
Show different text in title and body for clarity

### DIFF
--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -59,7 +59,7 @@ The simplest, valid HTML `Hello world` is:
     <title>Hello World from title</title>
   </head>
   <body>
-    <p>Hello World from body</p>
+    <p>Hello World</p>
   </body>
 </html>
 ~~~

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -56,10 +56,10 @@ The simplest, valid HTML `Hello world` is:
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Hello World</title>
+    <title>Hello World from title</title>
   </head>
   <body>
-    <p>Hello World</p>
+    <p>Hello World from body</p>
   </body>
 </html>
 ~~~

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -56,7 +56,7 @@ The simplest, valid HTML `Hello world` is:
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Hello World from title</title>
+    <title>Page title</title>
   </head>
   <body>
     <p>Hello World</p>


### PR DESCRIPTION
Title is required for valid HTML but using the same text as in the body can cause some confusion.