### PR TITLE
add estimated timings

### DIFF
--- a/_episodes/github-pages.md
+++ b/_episodes/github-pages.md
@@ -1,7 +1,7 @@
 ---
 title: "Hosting Websites on GitHub"
-teaching: 0
-exercises: 0
+teaching: 20
+exercises: 20
 questions:
 - "How do I publish my page or a website on the Web via GitHub?"
 objectives:

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -1,7 +1,7 @@
 ---
 title: "Introduction"
-teaching: 0
-exercises: 0
+teaching: 30
+exercises: 10
 questions:
 - "What is static web content?"
 - "Why should I use GitHub or GitLab Pages to create my website?"

--- a/_episodes/markdown.md
+++ b/_episodes/markdown.md
@@ -1,7 +1,7 @@
 ---
 title: "Authoring with Markdown"
-teaching: 0
-exercises: 0
+teaching: 20
+exercises: 15
 questions:
 - "How can I write content for my webpages?"
 - "How do I link to other pages?"
@@ -88,7 +88,7 @@ Repo for learning how to make websites with Jekyll pages
 Vanilla text may contain *italic* and **bold words**.
 
 This paragraph is separated from the previous one by a blank line.
-Line breaks  
+Line breaks
 are caused by two trailing spaces at the end of a line.
 
 [Carpentries Webpage](https://carpentries.org/)

--- a/_episodes/starting-jekyll.md
+++ b/_episodes/starting-jekyll.md
@@ -1,7 +1,7 @@
 ---
 title: "Starting with Jekyll"
-teaching: 0
-exercises: 0
+teaching: 20
+exercises: 10
 questions:
 - "How can I use values stored in variables in my pages?"
 - "How can I configure global values/settings for my site?"
@@ -227,7 +227,7 @@ Between these triple-dashed lines, you can overwrite predefined variables (like 
 > > Have any questions about what we do? [We'd love to hear from you!]({% raw %}mailto:{{ site.email }}{% endraw %})
 > > ~~~
 > > {: .language-markdown }
-> > 
+> >
 > > Note that this variable is not accessible from `about.md` page and is local to `index.md`.
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
For the first four episodes, as that was what we were able to cover in the two UW-Madison alpha pilots.

This adds up to 2hr25min, which seems a bit short but not far off what we used during the trial runs (taking into account introductory notes, breaks, and time spent wrapping up and answering questions at the end). 