### PR TITLE
Adding glossario references

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -7,11 +7,12 @@ layout: reference
 - <a href="https://glosario.carpentries.org/en/#git_branch" class="glossary-definition">Branch</a>
 - <a href="https://glosario.carpentries.org/en/#commit" class="glossary-definition">Commit</a>
 - <a href="https://glosario.carpentries.org/en/#css" class="glossary-definition">CSS</a>
+- <a href="https://carpentries.github.io/glosario/en/#dry" class="glossary-definition">DRY (Don't repeat yourself) principles</a>
 - <a href="https://glosario.carpentries.org/en/#git" class="glossary-definition">Git</a>
 - <a href="https://glosario.carpentries.org/en/#github" class="glossary-definition">GitHub</a>
 - <a href="https://glosario.carpentries.org/en/#html" class="glossary-definition">HTML</a>  
 - <a href="https://glosario.carpentries.org/en/#markdown" class="glossary-definition">Markdown</a> 
-- README 
+- <a href="https://carpentries.github.io/glosario/en/#readme" class="glossary-definition">README</a>
 - <a href="https://glosario.carpentries.org/en/#repository" class="glossary-definition">Repository/repo</a>
 - <a href="https://glosario.carpentries.org/en/#version_control_system" class="glossary-definition">Version Control</a>
 - <a href="https://glosario.carpentries.org/en/#yaml" class="glossary-definition">YAML</a>

--- a/reference.md
+++ b/reference.md
@@ -4,6 +4,15 @@ layout: reference
 
 ## Glossary
 
-FIXME
+- <a href="https://glosario.carpentries.org/en/#git_branch" class="glossary-definition">Branch</a>
+- <a href="https://glosario.carpentries.org/en/#commit" class="glossary-definition">Commit</a>
+- <a href="https://glosario.carpentries.org/en/#css" class="glossary-definition">CSS</a>
+- <a href="https://glosario.carpentries.org/en/#git" class="glossary-definition">Git</a>
+- <a href="https://glosario.carpentries.org/en/#github" class="glossary-definition">GitHub</a>
+- <a href="https://glosario.carpentries.org/en/#html" class="glossary-definition">HTML</a>  
+- <a href="https://glosario.carpentries.org/en/#markdown" class="glossary-definition">Markdown</a> 
+- README 
+- <a href="https://glosario.carpentries.org/en/#repository" class="glossary-definition">Repository/repo</a>
+- <a href="https://glosario.carpentries.org/en/#version_control_system" class="glossary-definition">Version Control</a>
 
 {% include links.md %}

--- a/reference.md
+++ b/reference.md
@@ -14,5 +14,6 @@ layout: reference
 - README 
 - <a href="https://glosario.carpentries.org/en/#repository" class="glossary-definition">Repository/repo</a>
 - <a href="https://glosario.carpentries.org/en/#version_control_system" class="glossary-definition">Version Control</a>
+- <a href="https://glosario.carpentries.org/en/#yaml" class="glossary-definition">YAML</a>
 
 {% include links.md %}


### PR DESCRIPTION
Started the draft of this based on jargon busting section Aleks presented in the 2020-11-25 pilot.

Working on getting [README definition into glossario](https://github.com/carpentries/glosario/pull/233) before merging.


Fixes #143 
