### PR TITLE
fixes exercise names

### DIFF
--- a/_episodes/arrays.md
+++ b/_episodes/arrays.md
@@ -109,7 +109,7 @@ Let's access the information about the team and display the name of the project 
 If you need to add, remove or modify a team member, you can simply do it in `_config.yml` without modifying your pages.
 Let's now change the values of a global parameter and study the effect.
 
-> ## Exercise
+> ## Exercise: Personnel Changes
 > Your project team has changed. The team lead has left and in her place is a new person: 'Tom Cat', who started on
 > '2020-10-01'. In addition, the team was expanded and a new developer called 'Alice Dauncey' who joined on '2020-09-15'.
 > Update your website to reflect these team changes.

--- a/_episodes/filters.md
+++ b/_episodes/filters.md
@@ -74,7 +74,7 @@ FIXME: add screenshot of rendered blog post.
 This is a good start! Let's make a second post before we try to further improve
 our post layout.
 
-> ## Creating Another Post
+> ## Exercise: Creating Another Post
 >
 > Write another blog post, in a file called `1851-05-16-DIG.md`,
 > so that the rendered page looks like this:
@@ -125,7 +125,7 @@ in the example above, it converts the format of the date string.
 We will explore the `"ordinal"` part in the exercise below.
 
 
-> ## Date Formats
+> ## Exercise: Date Formats
 >
 > `"ordinal"` is being passed as an argment to the `date_to_long_string` filter.
 > To see how this argument is changing the behaviour of the filter,

--- a/_episodes/includes.md
+++ b/_episodes/includes.md
@@ -19,7 +19,7 @@ However, repeated use of content in and across websites
 is usually not limited to individual values such as
 email addresses and social media handles.
 
-> ## What gets re-used?
+> ## Exercise: What Gets Re-used?
 >
 > Look at the two pages linked below,
 > and browse some other pages on the same site.
@@ -147,7 +147,7 @@ at the top of your page.
 > and the alt text as the `alt` parameter.
 {: .callout }
 
-> ## Optional Exercise
+> ## Optional Exercise: Creating a Linked Banner
 >
 > It is common for banner logos like the one above to link back to the homepage
 > of the website they are displayed on.
@@ -219,7 +219,7 @@ We will see another example of this shortly.
 > and using it in a page (`{% raw %}{{site.social}}{% endraw %}` for the example above).
 {: .callout }
 
-> ## Including Contact Information
+> ## Exercise: Including Contact Information
 >
 > The last line of `index.md` includes the kind of information you might want to
 > re-use in multiple places throughout your site.

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -87,7 +87,7 @@ a web browser will make a best guess regarding the layout of HTML elements on th
 > covering a rich range of features powering today's [world wide web][www-wikipedia].
 {: .callout }
 
-> ## Writing Basic HTML
+> ## Exercise: Writing Basic HTML
 >
 > Given the stylized text:
 >
@@ -147,7 +147,7 @@ Among other things this means that,
 unlike with static pages (see the rest of this lesson),
 you're unlikely to find cost-free platforms to help you deliver dynamic content.
 
-> ## The perfect tool for the job
+> ## Exercise: The Perfect Tool for the Job
 >
 > Given the following types of websites,
 > reason if a static site generator is an appropriate solution to implement them.

--- a/_episodes/layouts.md
+++ b/_episodes/layouts.md
@@ -106,7 +106,7 @@ The duplication is happening because the
 `{% raw %}{% include banner.md %}{% endraw %}`
 tag is still present in `index.md`.
 
-> ## Cleaning up
+> ## Exercise: Cleaning Up
 >
 > Remove the include tag for the banner from all the pages of your site,
 > and set every page to use the `page` layout.
@@ -126,7 +126,7 @@ we will need to start telling the browser how we would like our pages to be styl
 There is still more to learn about page layouts,
 so we will come back to this issue of styling at the end of the section.
 
-> ## Expanding the layout
+> ## Exercise: Expanding the Layout
 >
 > We will probably want to include the contact line we added in the previous section
 > in every standard page on our site.
@@ -192,7 +192,7 @@ It is common practice to define the structural elements of your site's pages
 inside a `_layouts/default.html` file.
 This file defines the bare minimum layout your pages should have.
 
-> ## Laying the groundwork
+> ## Exercise: Laying the Groundwork
 >
 > Create another layout file, `default.html`, with the following content:
 >

--- a/_episodes/markdown.md
+++ b/_episodes/markdown.md
@@ -112,7 +112,7 @@ Scroll down to the bottom of the page, add a commit message if you wish, and the
 
 Let's do an exercise to try out writing more markdown.
 
-> ## Try out Markdown
+> ## Exercisee: Try Out Markdown
 > Use [this cheatsheet][github-flavored-markdown] to add to your readme:
 >
 > - Another second level heading

--- a/_episodes/starting-jekyll.md
+++ b/_episodes/starting-jekyll.md
@@ -115,7 +115,7 @@ Let's make use of global parameters in our pages.
 4. Note that site parameters will not render nicely when viewing files in GitHub (they will be displayed as text
 `{% raw %}{{ site.PARAMETER_NAME }}{% endraw %}` rather than the parameter's rendered value) but will in the website.
 
-> ## Exercise
+> ## Exercise: Create a Global Twitter Parameter
 > In `about.md` we have a Twitter URL under the 'Contact us' section. That's one piece of information that could go into
 > global parameters in `_config.yml` as you may want to repeat it on a footer of every page.
 > Make changes to your website to extract Twitter URL as a global parameter.
@@ -194,7 +194,7 @@ author: "Danger Mouse"
 
 Between these triple-dashed lines, you can overwrite predefined variables (like `page.layout` or `page.title`) or create custom ones you need locally on the page (like `page.author`). These variables will then be available for you to access using Liquid's tags {% raw %}{{{% endraw %} and {% raw %}}}{% endraw %} further down in the file and also in any files that include this one.
 
-> ## Exercise
+> ## Exercise: Practice with Local Variables
 >
 > Let's practice making and using local variables. Think of a local variable you may want to use only in your `about.md` or `index.md` page.
 > If you cannot think of any, create a local variable called 'lesson-example' with the value


### PR DESCRIPTION
Changes exercises to all...
- Use title case
- have same format (I kept the "Exercise: NAME" format)
- have names

Fixes #159

Also addresses #50 for exercises 