### PR TITLE
remove phantom source tag

### DIFF
--- a/_episodes/arrays.md
+++ b/_episodes/arrays.md
@@ -607,7 +607,6 @@ version of the site as well as on GitHub Pages.
 > It is a blog template that uses Jekyll as a base, improves on Jekyll experience and offers additional features.
 > For researchers this may be the option to go.
 >
-> {: .source}
 {: .callout}
 
 {% include links.md %}


### PR DESCRIPTION
I found this stray tag and could not find a use for it and have removed it as it was causing errors when I was attempting to convert this lesson. 